### PR TITLE
Revert usage of developer role

### DIFF
--- a/custom_components/openai_compatible_conversation/conversation.py
+++ b/custom_components/openai_compatible_conversation/conversation.py
@@ -106,12 +106,9 @@ def _convert_content_to_param(
             content=json.dumps(content.tool_result),
         )
     if content.role != "assistant" or not content.tool_calls:  # type: ignore[union-attr]
-        role = content.role
-        if role == "system":
-            role = "developer"
         return cast(
             ChatCompletionMessageParam,
-            {"role": role, "content": content.content},  # type: ignore[union-attr]
+            {"role": content.role, "content": content.content},  # type: ignore[union-attr]
         )
 
     # Handle the Assistant content including tool calls.


### PR DESCRIPTION
We were previously using the new developer role from OpenAI's API, but this doesn't seem to be compatible with other non-OpenAI APIs, so reverting back to system role for now.